### PR TITLE
Update required version in composer.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Update your `composer.json` file to include this package as a dependency
 ```json
-"thomaswelton/laravel-gravatar": "0.0.x"
+"thomaswelton/laravel-gravatar": "0.1.x"
 ```
 
 Register the Gravatar service provider by adding it to the providers array in the `app/config/app.php` file.


### PR DESCRIPTION
The README instructions where behind the latest version available. This PR fixes this (see issue https://github.com/thomaswelton/laravel-gravatar/issues/11)
