### PR TITLE
Broken path

### DIFF
--- a/src/LaravelGravatarServiceProvider.php
+++ b/src/LaravelGravatarServiceProvider.php
@@ -19,7 +19,7 @@ class LaravelGravatarServiceProvider extends ServiceProvider
      */
     protected function setupConfig()
     {
-        $source = realpath(__DIR__.'/../../../config/gravatar.php');
+        $source = realpath(__DIR__.'/../config/gravatar.php');
         $this->publishes([$source => config_path('gravatar.php')]);
         $this->mergeConfigFrom($source, 'gravatar');
     }


### PR DESCRIPTION
Somehow a flaw slipped through in the last update – causing entire projects to break on `composer update`... Haven't had the chance/time to spot anything else that might be wrong.

Error occurs on composer update, if you haven't specified a specific release (i.e. 1.0.0) but instead for example `~1.0` which would bring in 1.1.0. 