### PR TITLE
Add Laravel 5.4 support

### DIFF
--- a/src/LaravelGravatarServiceProvider.php
+++ b/src/LaravelGravatarServiceProvider.php
@@ -29,7 +29,7 @@ class LaravelGravatarServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app['gravatar'] = $this->app->share(function ($app) {
+        $this->app->singleton('gravatar', function ($app) {
             return new Gravatar($this->app['config']);
         });
     }


### PR DESCRIPTION
Laravel 5.4 removed the `share` method on the container in favor for `singleton`, as described in the 5.4 upgrade guide: https://laravel.com/docs/5.4/upgrade