### PR TITLE
Add support for Laravel 6 & 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.4
-    - php: 5.5
     - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
       env: COLLECT_COVERAGE=true
-    - php: 7
-    - php: hhvm
+    - php: 7.3
 
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
    ],
    "require":{
       "php":">=5.4.0",
-      "illuminate/support":"~5.0",
+      "illuminate/support":"~5.0|^6.0|^7.0",
       "thomaswelton/gravatarlib":"0.1.x"
    },
    "require-dev":{


### PR DESCRIPTION
I have added this pull request to remove older php versions (including hhvm) and test newer php versions on Travis.

I've also built-in a future proof for the yet to be released Laravel 7, similar to what is done on the socialite repo (https://github.com/laravel/socialite/blob/4.0/composer.json#L22).